### PR TITLE
docs: finish canonical URL migration

### DIFF
--- a/ALGORITHM_DEPLOYMENT.md
+++ b/ALGORITHM_DEPLOYMENT.md
@@ -55,7 +55,7 @@ pip install torch numpy pybind11 PyYAML pandas
 
 ```bash
 # 1. 克隆仓库并初始化 submodules
-git clone https://github.com/intellistream/SAGE-DB-Bench.git
+git clone https://github.com/DataSysResearch/CANDOR-Bench.git
 cd SAGE-DB-Bench
 git submodule update --init --recursive
 
@@ -360,7 +360,7 @@ set -e
 apt-get update && apt-get install -y build-essential cmake libgflags-dev libboost-all-dev
 
 # 克隆并初始化
-git clone --recurse-submodules https://github.com/intellistream/SAGE-DB-Bench.git
+git clone --recurse-submodules https://github.com/DataSysResearch/CANDOR-Bench.git
 cd SAGE-DB-Bench
 
 # 安装 Python 依赖
@@ -412,5 +412,5 @@ git submodule add <repo_url> <folder_name>
 ## 支持
 
 - **文档**: [algorithms_impl/README.md](algorithms_impl/README.md)
-- **Issues**: https://github.com/intellistream/SAGE-DB-Bench/issues
-- **Wiki**: https://github.com/intellistream/SAGE-DB-Bench/wiki
+- **Issues**: https://github.com/DataSysResearch/CANDOR-Bench/issues
+- **Wiki**: https://github.com/DataSysResearch/CANDOR-Bench/wiki

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,10 +102,10 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/intellistream/SAGE-DB-Bench"
-Documentation = "https://github.com/intellistream/SAGE-DB-Bench/blob/main/README.md"
-Repository = "https://github.com/intellistream/SAGE-DB-Bench"
-"Bug Tracker" = "https://github.com/intellistream/SAGE-DB-Bench/issues"
+Homepage = "https://github.com/DataSysResearch/CANDOR-Bench"
+Documentation = "https://github.com/DataSysResearch/CANDOR-Bench/blob/main/README.md"
+Repository = "https://github.com/DataSysResearch/CANDOR-Bench"
+"Bug Tracker" = "https://github.com/DataSysResearch/CANDOR-Bench/issues"
 
 [project.scripts]
 sage-bench = "bench.cli:main"


### PR DESCRIPTION
Replaces remaining user-facing pre-migration GitHub URLs while preserving compatibility namespaces and historical copyright attribution.